### PR TITLE
add 2026 featured talks page

### DIFF
--- a/src/_data/navigation.json
+++ b/src/_data/navigation.json
@@ -20,12 +20,8 @@
       "target": "_blank"
     },
     {
-      "text": "Talks",
-      "url": "/archive/2025"
-    },
-    {
-      "text": "Gadget 2025",
-      "url": "/gadget2025"
+      "text": "Featured Talks",
+      "url": "/2026/talk-list/"
     },
     {
       "text": "Team",
@@ -37,7 +33,7 @@
     },
     {
       "text": "Archive",
-      "url": "/archive/2024"
+      "url": "/archive/2025"
     }
   ]
 }

--- a/src/_includes/layouts/talk-list.njk
+++ b/src/_includes/layouts/talk-list.njk
@@ -5,8 +5,12 @@
   <section>
     <div class="wrapper-l | stack-700">
       <h1 class="leading-tight uppercase text-800-major weight-black text-peach">
-      Talk List {{ year }}!
+      {{ title or "Talk List" }} {{ year }}
     </h1>
+
+      {% if intro %}
+        <p class="text-400-500">{{ intro }}</p>
+      {% endif %}
 
       <div class="stack-100">
         {% for talk in talks %}

--- a/src/_includes/layouts/talk.njk
+++ b/src/_includes/layouts/talk.njk
@@ -13,15 +13,17 @@
          {% include "partials/speaker-pill.njk" %}
       {% endfor %}
     </div>
-    <p class="weight-bold">
-      {% set slot = talk.slots[0] %}
-      {{ slot.room.name.en }},
-      {% if slot.start %}
-        <time datetime="{{ slot.start | toISODate }}">
-          {{ slot.start | dateFormat("EEEE, MM/dd") }}
-        </time>
-      {% endif %}
-    </p>
+    {% if talk.slots.length %}
+      <p class="weight-bold">
+        {% set slot = talk.slots[0] %}
+        {{ slot.room.name.en }},
+        {% if slot.start %}
+          <time datetime="{{ slot.start | toISODate }}">
+            {{ slot.start | dateFormat("EEEE, MM/dd") }}
+          </time>
+        {% endif %}
+      </p>
+    {% endif %}
     <div class="wrapper-s shadow-box stack-400 my-stack-space-600">
       {% for video in videos %}
         {% if video.submission == talk.code %}
@@ -56,8 +58,10 @@
       <div class="wrapper-s">
         {% if year < years.currentYear %}
           <a href="/archive/{{year}}" class="uppercase weight-bold text-peach">&#60; Back to archive</a>
-        {% else %}
+        {% elif hasSchedule %}
           <a href="/{{year}}/schedule" class="uppercase weight-bold text-peach">&#60; Back to schedule</a>
+        {% else %}
+          <a href="/{{year}}/talk-list" class="uppercase weight-bold text-peach">&#60; Back to featured talks</a>
         {% endif %}
       </div>
 

--- a/src/pages/2026/2026.11tydata.js
+++ b/src/pages/2026/2026.11tydata.js
@@ -1,0 +1,90 @@
+// @ts-check
+import Cache from "@11ty/eleventy-cache-assets";
+
+/**
+ * OSFC 2026 event data from Pretalx.
+ *
+ * Pre-schedule phase: the full schedule is not published yet, so we surface the
+ * "featured" talks (is_featured) as a teaser. Talks and speakers are fetched
+ * independently of the schedule/breaks/videos, and those schedule-dependent
+ * pieces are guarded so a missing (404) schedule export cannot empty the talk
+ * list. When the schedule is live:
+ *   1. set "hasSchedule": true in 2026.json,
+ *   2. add schedule.md / talks.md (copy from a previous year),
+ *   3. widen the talk filter (e.g. state === "confirmed").
+ */
+
+const EVENT = "osfc-2026";
+const BASE = "https://talks.osfc.io/api/events";
+const SCHEDULE_EXPORT = `https://talks.osfc.io/${EVENT}/schedule/export/schedule.json`;
+
+// Pretalx API token with read access to osfc-2026 (checked in, as in prior years).
+const TOKEN = "wauehwu6exc0rp3unk6yd6hublaqj87mz7v6yzdoksc4t3woe4efi4r79kn5qb1o";
+
+const jsonAuth = (duration) => ({
+  duration,
+  type: "json",
+  fetchOptions: { headers: { Authorization: `Token ${TOKEN}` } },
+});
+
+/** Page through the paginated submissions endpoint. */
+async function fetchAllSubmissions() {
+  const all = [];
+  let url = `${BASE}/${EVENT}/submissions/?format=json&limit=200&expand=speakers,slots,slots.room,resources`;
+  while (url) {
+    const page = await Cache(url, jsonAuth("1m"));
+    all.push(...(page.results || []));
+    url = page.next;
+  }
+  // De-dupe by code (defensive against overlapping pages).
+  return Array.from(all.reduce((m, t) => m.set(t.code, t), new Map()).values());
+}
+
+export default async () => {
+  let talks = [];
+  let speakers = [];
+
+  try {
+    const submissions = await fetchAllSubmissions();
+    // Featured talks only, until the full schedule is published. Guard against a
+    // talk that is still flagged featured but has since been pulled.
+    const HIDDEN_STATES = ["withdrawn", "canceled", "cancelled", "rejected", "deleted"];
+    talks = submissions
+      .filter((talk) => talk.is_featured && !HIDDEN_STATES.includes(talk.state))
+      .sort((a, b) => (a.title > b.title ? 1 : -1));
+
+    const speakerData = await Cache(
+      `${BASE}/${EVENT}/speakers/?format=json&limit=200`,
+      jsonAuth("1m")
+    );
+
+    // Only include speakers who actually have a featured talk.
+    const featuredSpeakerCodes = new Set(
+      talks.flatMap((talk) => (talk.speakers || []).map((speaker) => speaker.code))
+    );
+    speakers = (speakerData.results || [])
+      .filter((speaker) => speaker.name && featuredSpeakerCodes.has(speaker.code))
+      .sort((a, b) => (a.name > b.name ? 1 : -1));
+  } catch (error) {
+    console.error("[osfc-2026] could not load talks/speakers:", error.message);
+  }
+
+  // Schedule-dependent data — guarded so its absence never empties the talk list.
+  let schedule = { days: [], rooms: [] };
+  let breaks = [];
+  const videos = [];
+
+  try {
+    const scheduleData = await Cache(SCHEDULE_EXPORT, jsonAuth("1d"));
+    schedule = scheduleData.schedule.conference;
+    const breakData = await Cache(
+      `${BASE}/${EVENT}/schedules/latest/?format=json`,
+      jsonAuth("1d")
+    );
+    breaks = breakData.breaks;
+  } catch (error) {
+    console.warn("[osfc-2026] schedule not published yet — schedule/breaks skipped.");
+  }
+
+  return { talks, speakers, schedule, breaks, videos };
+};

--- a/src/pages/2026/2026.json
+++ b/src/pages/2026/2026.json
@@ -1,0 +1,5 @@
+{
+  "year": "2026",
+  "transparentHeader": true,
+  "hasSchedule": false
+}

--- a/src/pages/2026/speaker.md
+++ b/src/pages/2026/speaker.md
@@ -1,0 +1,9 @@
+---
+pagination:
+  data: speakers
+  size: 1
+layout: "layouts/speaker.njk"
+eleventyComputed:
+  title: "{{ pagination.items[0].name }}"
+permalink: "2026/speakers/{{ pagination.items[0].name | slugify }}/index.html"
+---

--- a/src/pages/2026/talk-list.md
+++ b/src/pages/2026/talk-list.md
@@ -1,0 +1,6 @@
+---
+title: "Featured Talks"
+intro: "A selection of featured sessions to give you a feel for OSFC 2026. This is not the full schedule — we will follow up with the complete program soon."
+layout: "layouts/talk-list.njk"
+permalink: "/2026/talk-list/index.html"
+---

--- a/src/pages/2026/talk.md
+++ b/src/pages/2026/talk.md
@@ -1,0 +1,10 @@
+---
+pagination:
+  data: talks
+  size: 1
+  alias: talk
+eleventyComputed:
+  title: "{{ talk.title }}"
+layout: "layouts/talk.njk"
+permalink: "/2026/talks/{{ talk.title | slugify }}/index.html"
+---


### PR DESCRIPTION
Surface the osfc-2026 featured talks (is_featured) natively at /2026/talk-list/, ahead of the full schedule, with talk detail and speaker pages. The year data file fetches talks/speakers independently and guards the schedule/breaks/videos so the not-yet-published schedule export can't empty the list.

- nav: add "Featured Talks", remove "Gadget 2025", point Archive at 2025
- talk layout: guard empty schedule slot and use a pre-schedule back-link